### PR TITLE
Handle the disc_simu.txt

### DIFF
--- a/package/src/simulator_sw_0701/simu.py
+++ b/package/src/simulator_sw_0701/simu.py
@@ -1,5 +1,6 @@
 """
 By: Shiyi Wang
+Date: 2023-07-11
 """
 
 import argparse

--- a/package/src/simulator_sw_0701/simu.py
+++ b/package/src/simulator_sw_0701/simu.py
@@ -1,3 +1,7 @@
+"""
+By: Shiyi Wang
+"""
+
 import argparse
 import os
 import numpy as np


### PR DESCRIPTION
The disc_simu.txt is an alternative solution to start several simulation runs. Instead of providing a range of starting materials, it specifies individual starting materials to use.  It should be more commonly used in the 'cont' mode to re-run several simulation runs.

I used to use the format of '1, 3, 5'. But @robert-vogel  commit provides me with a better solution. So now the format is 1\n3\n5\n.

Additionally, I add an example 'disc_simu.txt' in the test folder.